### PR TITLE
fix output when src file spec uses wildcards

### DIFF
--- a/tasks/jscrambler.js
+++ b/tasks/jscrambler.js
@@ -51,7 +51,7 @@ module.exports = function (grunt) {
             if (elem.src.length === 1 && lastDestChar !== '/' && lastDestChar !== '\\') {
               destPath = dest;
             } else {
-              destPath = path.join(dest, file);
+              destPath = path.join(dest, path.basename(file));
             }
             grunt.file.write(destPath, buffer);
           }


### PR DESCRIPTION
The full src path was being appended to the dest path when outputting.
This was creating duplicated parts of the path on output when using the
cwd option.